### PR TITLE
Added ParticlePatch

### DIFF
--- a/ThatDefaultProject/Assets/ThatDefaultProject/Scripts/IHasTransform.cs
+++ b/ThatDefaultProject/Assets/ThatDefaultProject/Scripts/IHasTransform.cs
@@ -1,0 +1,9 @@
+using UnityEngine;
+
+namespace that
+{
+    public interface IHasTransform
+    {
+		public Transform GetTransform();
+	}
+}

--- a/ThatDefaultProject/Assets/ThatDefaultProject/Scripts/IHasTransform.cs.meta
+++ b/ThatDefaultProject/Assets/ThatDefaultProject/Scripts/IHasTransform.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2cf4eeadd9f687b4b9c4964dea121020
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ThatDefaultProject/Assets/ThatDefaultProject/Scripts/ParticlePatch.cs
+++ b/ThatDefaultProject/Assets/ThatDefaultProject/Scripts/ParticlePatch.cs
@@ -1,0 +1,76 @@
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+namespace that
+{
+	[CreateAssetMenu(menuName = "ThatRFX/ParticlePatch")]
+	public class ParticlePatch : ScriptableObject
+	{
+		[SerializeField] private GameObject[] _particlePrefabs;
+		private List<GameObject> _uniqueParicles;
+		[SerializeField] private float _longestEffectTime = 1.0f;
+		[SerializeField] private bool _supressWarnings = false;
+
+		private void Awake()
+		{
+			Debug.Assert(_particlePrefabs.Length > 0, $"ParticlePrefabs is empty on ParticlePatch {name}");
+			if (_particlePrefabs != null && _particlePrefabs.Length > 0)
+			{
+				_uniqueParicles = _particlePrefabs.ToList();
+			}
+		}
+
+		public void PlayAttached(Transform transform)
+		{
+			if (!transform.gameObject.activeInHierarchy)
+			{
+#if UNITY_EDITOR
+				if (_supressWarnings)
+				{
+					Debug.LogWarning($"[ParticlePatch] {name} is played on an inactive transform and is refusing to playattached.");
+				}
+#endif
+				return;
+			}
+			GameObject obj = Instantiate(ReturnRandomPrefab(), transform);
+			DestroyTimer destroyTimer = obj.AddComponent<DestroyTimer>();
+			destroyTimer.Time = _longestEffectTime;
+			destroyTimer.StartTimer();
+		}
+
+		public void PlayTrailing(Transform transform)
+		{
+			GameObject trailing = SpawnTrailing(transform);
+			PlayAttached(trailing.transform);
+		}
+
+		private GameObject ReturnRandomPrefab()
+		{
+			if (_particlePrefabs.Length == 1)
+			{
+				return _particlePrefabs[0];
+			}
+			Debug.Assert(_particlePrefabs.Length != 0, $"ParticlePatch ({name}) is empty!");
+			if (_uniqueParicles.Count <= 0)
+			{
+				_uniqueParicles = _particlePrefabs.ToList();
+			}
+			int randomIndex = Random.Range(0, _uniqueParicles.Count);
+			GameObject randomPrefab = _uniqueParicles[randomIndex];
+			_uniqueParicles.RemoveAt(randomIndex);
+
+			return randomPrefab;
+		}
+
+		private GameObject SpawnTrailing(Transform transform)
+		{
+			GameObject obj = new("[ParticlePatch] Trailing Particles");
+			obj.transform.SetPositionAndRotation(transform.position, transform.rotation);
+			DestroyTimer destroyTimer = obj.AddComponent<DestroyTimer>();
+			destroyTimer.Time = _longestEffectTime;
+			destroyTimer.StartTimer();
+			return obj;
+		}
+	}
+}

--- a/ThatDefaultProject/Assets/ThatDefaultProject/Scripts/ParticlePatch.cs
+++ b/ThatDefaultProject/Assets/ThatDefaultProject/Scripts/ParticlePatch.cs
@@ -47,6 +47,9 @@ namespace that
 			PlayAttached(trailing.transform);
 		}
 
+		public void PlayAttached(IHasTransform hasTransform) => PlayAttached(hasTransform.GetTransform());
+		public void PlayTrailing(IHasTransform hasTransform) => PlayTrailing(hasTransform.GetTransform());
+
 		private GameObject ReturnRandomPrefab()
 		{
 			if (_particlePrefabs.Length == 1)

--- a/ThatDefaultProject/Assets/ThatDefaultProject/Scripts/ParticlePatch.cs
+++ b/ThatDefaultProject/Assets/ThatDefaultProject/Scripts/ParticlePatch.cs
@@ -14,6 +14,8 @@ namespace that
 
 		private void Awake()
 		{
+			if (_particlePrefabs == null) return;
+
 			Debug.Assert(_particlePrefabs.Length > 0, $"ParticlePrefabs is empty on ParticlePatch {name}");
 			if (_particlePrefabs != null && _particlePrefabs.Length > 0)
 			{

--- a/ThatDefaultProject/Assets/ThatDefaultProject/Scripts/ParticlePatch.cs.meta
+++ b/ThatDefaultProject/Assets/ThatDefaultProject/Scripts/ParticlePatch.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0f642dc920df3304aae77b172946580c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ThatDefaultProject/Assets/ThatDefaultProject/Scripts/ParticlePatchTester.cs
+++ b/ThatDefaultProject/Assets/ThatDefaultProject/Scripts/ParticlePatchTester.cs
@@ -1,0 +1,31 @@
+using UnityEngine;
+
+namespace that
+{
+	public class ParticlePathTester : MonoBehaviour
+	{
+		private enum PlayMethod { PlayAttached, PlayTrailing }
+
+		[SerializeField] private bool _play = false;
+		[SerializeField] private ParticlePatch _particlePatch;
+		[SerializeField] private PlayMethod _playMethod;
+		[SerializeField] private Transform _targetTransform;
+
+		void Update()
+		{
+			if (_play == false) return;
+
+			_play = false;
+			Transform transformToUse = _targetTransform != null ? _targetTransform : transform;
+			switch (_playMethod)
+			{
+				case PlayMethod.PlayAttached:
+					_particlePatch.PlayAttached(transformToUse);
+					break;
+				case PlayMethod.PlayTrailing:
+					_particlePatch.PlayTrailing(transformToUse);
+					break;
+			}
+		}
+	}
+}

--- a/ThatDefaultProject/Assets/ThatDefaultProject/Scripts/ParticlePatchTester.cs.meta
+++ b/ThatDefaultProject/Assets/ThatDefaultProject/Scripts/ParticlePatchTester.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: baa15937abd2ed34d8937a38d8be01ae
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
ParticlePatch is a similar system as AudioPatch as it is a scriptable object intended to be used with UnityEvents.

It assumes the particle will play on itself.